### PR TITLE
backend: refine device API

### DIFF
--- a/libookapi/tests/test_device.py
+++ b/libookapi/tests/test_device.py
@@ -28,8 +28,9 @@ def test_get_device():
     group = RegionGroup.objects.create(name="新图 1 楼")
     region = Region.objects.create(name="新图 E100", capacity=100, group=group)
     device = Device.objects.create(api_key="2333333", region=region)
+    current_time = now()
     time = Timeslice.objects.create(
-        from_time=now(), to_time=now() + timedelta(hours=1))
+        from_time=current_time, to_time=current_time + timedelta(hours=1))
     User.objects.create(username="Alex Chi")  # Ensure test user is not ID 1
     user = User.objects.create(username="Bob Chi")
     user_info = UserInfo.objects.create(
@@ -38,14 +39,20 @@ def test_get_device():
         user=user, time=time, region=region)
     client = APIClient()
     response = client.get(
-        f'/api/devices/{device.id}', {"api_key": device.api_key})
+        f'/api/devices/{device.id}', {
+            "api_key": device.api_key,
+            "from_time": current_time,
+            "to_time": current_time + timedelta(hours=1)})
     assert response.status_code == 200
     result = response.json()
     assert result[0]['id'] == reservation.id
     assert result[0]['user']['id'] == user.id
     assert result[0]['user']['user_info']['fingerprint_id'] == 2
     response = client.get(
-        f'/api/devices/{device.id}', {"api_key": device.api_key, "fake": "false"})
+        f'/api/devices/{device.id}', {
+            "api_key": device.api_key, "fake": "false",
+            "from_time": current_time,
+            "to_time": current_time + timedelta(hours=1)})
     assert response.status_code == 200
     result = response.json()
     assert result[0]['id'] == reservation.id

--- a/libookapi/views/device.py
+++ b/libookapi/views/device.py
@@ -27,7 +27,11 @@ class DeviceView(views.APIView):
                              OpenApiParameter.PATH, description='设备 ID'),
             OpenApiParameter('api_key', OpenApiTypes.STR,
                              description='API Key'),
-            OpenApiParameter('fake', OpenApiTypes.BOOL, description='返回测试数据')
+            OpenApiParameter('fake', OpenApiTypes.BOOL, description='返回测试数据'),
+            OpenApiParameter(
+                'from_time', OpenApiTypes.DATETIME, description='起始时间'),
+            OpenApiParameter('to_time', OpenApiTypes.DATETIME,
+                             description='终止时间'),
         ],
         responses=DeviceReservationSerializer(many=True),
     )
@@ -41,8 +45,8 @@ class DeviceView(views.APIView):
                 return Response(FAKE_DATA, status.HTTP_200_OK)
             reservations = Reservation.objects.filter(
                 region=device.region,
-                time__from_time__lte=now(),
-                time__to_time__gte=now()).select_related()
+                time__from_time__gte=request.GET.get('from_time'),
+                time__from_time__lte=request.GET.get('to_time')).select_related()
             return Response(DeviceReservationSerializer(reservations, many=True).data, status.HTTP_200_OK)
         else:
             return Response('invalid credentials', status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
这个 PR 合并后，调用 Device API 需要传入 from_time 和 to_time。这样，设备就可以自己选择需要获取的当前座位预约的时间范围。