### PR TITLE
deploy: fix netlify cookie

### DIFF
--- a/booklib/public/_redirects
+++ b/booklib/public/_redirects
@@ -1,0 +1,2 @@
+/api/*  https://api.libook.skyzh.dev/api/:splat 200
+/*      /index.html   200

--- a/libook/settings_heroku.py
+++ b/libook/settings_heroku.py
@@ -28,16 +28,19 @@ DEBUG = False
 
 ALLOWED_HOSTS = [
     "api.libook.skyzh.dev",
+    "libook.skyzh.dev",
     "127.0.0.1",
     "localhost"
 ]
 
 CORS_ALLOWED_ORIGINS = [
-    "https://libook.skyzh.dev"
+    "https://libook.skyzh.dev",
+    "https://api.libook.skyzh.dev"
 ]
 
 CSRF_TRUSTED_ORIGINS = [
-    "libook.skyzh.dev"
+    "libook.skyzh.dev",
+    "api.libook.skyzh.dev"
 ]
 
 CSRF_COOKIE_DOMAIN = "libook.skyzh.dev"
@@ -45,6 +48,8 @@ CSRF_COOKIE_DOMAIN = "libook.skyzh.dev"
 CORS_ALLOW_CREDENTIALS = True
 
 SESSION_COOKIE_SAMESITE = None
+
+SESSION_COOKIE_DOMAIN = "libook.skyzh.dev"
 
 # Application definition
 

--- a/libook/wsgi.py
+++ b/libook/wsgi.py
@@ -13,4 +13,12 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'libook.settings')
 
-application = get_wsgi_application()
+django_app = get_wsgi_application()
+
+def netlify_fix_application(environ, start_response):
+    if "HTTP_COOKIE" in environ:
+        environ["HTTP_COOKIE"] = environ["HTTP_COOKIE"].replace(",", ";")
+    return django_app(environ, start_response)
+
+application = netlify_fix_application
+

--- a/libook/wsgi.py
+++ b/libook/wsgi.py
@@ -15,10 +15,11 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'libook.settings')
 
 django_app = get_wsgi_application()
 
+
 def netlify_fix_application(environ, start_response):
     if "HTTP_COOKIE" in environ:
         environ["HTTP_COOKIE"] = environ["HTTP_COOKIE"].replace(",", ";")
     return django_app(environ, start_response)
 
-application = netlify_fix_application
 
+application = netlify_fix_application


### PR DESCRIPTION
Netlify 在反代 API 请求时，Cookie 的分割符为 `,` 而非 `;`，导致 Python 无法解析。这个 PR 通过在 Python 端重写 cookie 字符串避免了这个问题。